### PR TITLE
bot actions can now be triggered sequentially without user inputs

### DIFF
--- a/src/main/i5/las2peer/services/socialBotManagerService/chat/ChatMediator.java
+++ b/src/main/i5/las2peer/services/socialBotManagerService/chat/ChatMediator.java
@@ -15,6 +15,7 @@ import java.net.URLEncoder;
 import java.util.*;
 
 public abstract class ChatMediator {
+	private ChatMessageCollector messageCollector;
 	protected String authToken;
 
 	public ChatMediator(String authToken) {
@@ -183,6 +184,10 @@ public abstract class ChatMediator {
 			return true;
 		} else
 			return false;
+	}
+
+	public ChatMessageCollector getMessageCollector() {
+		return messageCollector;
 	}
 
 	public abstract void close();

--- a/src/main/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
+++ b/src/main/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
@@ -537,6 +537,10 @@ public class RocketChatMediator extends ChatMediator implements ConnectListener,
 		super.sendBlocksMessageToChannel(channel, blocks);
 	}
 
+	public RocketChatMessageCollector getMessageCollector() {
+		return messageCollector;
+	}
+
 	@Override
 	public void close() {
 		shouldCheckRooms = false;

--- a/src/main/i5/las2peer/services/socialBotManagerService/chat/SlackChatMediator.java
+++ b/src/main/i5/las2peer/services/socialBotManagerService/chat/SlackChatMediator.java
@@ -545,6 +545,10 @@ public class SlackChatMediator extends EventChatMediator {
 		return null;
 	}
 
+	public SlackChatMessageCollector getMessageCollector() {
+		return messageCollector;
+	}
+
 	private void reconnect() {
 		if (!this.messageCollector.isConnected()) {
 			try {

--- a/src/main/i5/las2peer/services/socialBotManagerService/chat/TelegramChatMediator.java
+++ b/src/main/i5/las2peer/services/socialBotManagerService/chat/TelegramChatMediator.java
@@ -305,6 +305,10 @@ public class TelegramChatMediator extends EventChatMediator {
 
 	}
 
+	public TelegramMessageCollector getMessageCollector() {
+		return messageCollector;
+	}
+
 	@Override
 	public void sendBlocksMessageToChannel(String channel, String blocks) {
 		sendBlocksMessageToChannel(channel, blocks, Optional.empty());

--- a/src/main/i5/las2peer/services/socialBotManagerService/model/Messenger.java
+++ b/src/main/i5/las2peer/services/socialBotManagerService/model/Messenger.java
@@ -18,6 +18,7 @@ import java.util.Vector;
 import javax.websocket.DeploymentException;
 
 import i5.las2peer.services.socialBotManagerService.chat.*;
+import i5.las2peer.services.socialBotManagerService.chat.xAPI.ChatStatement;
 import i5.las2peer.services.socialBotManagerService.database.SQLDatabase;
 import i5.las2peer.services.socialBotManagerService.nlu.Entity;
 import i5.las2peer.services.socialBotManagerService.nlu.Intent;
@@ -170,12 +171,20 @@ public class Messenger {
 			if (state.getFollowingMessages() == null) {
 				System.out.println("Conversation flow ended now");
 			} else if (state.getFollowingMessages().get("") != null) {
+				// check whether bot action needs to be triggered without user input
 				state = state.getFollowingMessages().get("");
 				stateMap.put(channel, state);
 				System.out.println("1");
 				this.chatMediator.sendMessageToChannel(channel, state.getResponse(random).getResponse(), Optional.of(userid));
+						|| !state.getResponse(random).triggeredFunctionId.equals("")) {
+					this.chatMediator.getMessageCollector().addMessage(chatMsg);
+				}
 			} else {
+				// If only message to be sent
+				this.chatMediator.sendMessageToChannel(channel, state.getResponse(random).getResponse(),
+						Optional.of(userid));
 			}
+		} else {
 		}
 	}
 
@@ -191,6 +200,7 @@ public class Messenger {
 	// across
 	// threads somehow?
 	public void handleMessages(ArrayList<MessageInfo> messageInfos, Bot bot) {
+		System.out.println("asddasd");
 		Vector<ChatMessage> newMessages = this.chatMediator.getMessages();
 		for (ChatMessage message : newMessages) {
 			try {


### PR DESCRIPTION
Reason: Feedbot needs to send two files. This way, multiple bot actions can be triggered without user input.
Could have been done in a better way. 