### PR TITLE
Ba stuecker

### DIFF
--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/SocialBotManagerService.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/SocialBotManagerService.java
@@ -591,8 +591,8 @@ public class SocialBotManagerService extends RESTService {
 
 					MiniClient client = new MiniClient();
 					client.setConnectorEndpoint(basePath);
-					//client.setLogin(botAgent.getLoginName(), botPass); 
-					client.setLogin("alice", "pwalice");
+					client.setLogin(botAgent.getLoginName(), botPass); 
+					//client.setLogin("alice", "pwalice");
 
 					j.remove("joinPath");
 					j.remove("basePath");

--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/SocialBotManagerService.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/SocialBotManagerService.java
@@ -591,7 +591,8 @@ public class SocialBotManagerService extends RESTService {
 
 					MiniClient client = new MiniClient();
 					client.setConnectorEndpoint(basePath);
-					client.setLogin(botAgent.getLoginName(), botPass);
+					//client.setLogin(botAgent.getLoginName(), botPass); 
+					client.setLogin("alice", "pwalice");
 
 					j.remove("joinPath");
 					j.remove("basePath");

--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
@@ -511,7 +511,7 @@ public class RocketChatMediator extends ChatMediator implements ConnectListener,
 					String fileName = j.getJSONObject("file").getString("name");
 					System.out.println(j);
 					if (fileType.equals("text/plain") || fileType.equals("application/pdf")
-							|| fileType.equals("image/png") || fileType.equals("audio/aac")) || fileType.equals("audio/mpeg") {
+							|| fileType.equals("image/png") || fileType.equals("audio/aac") || fileType.equals("audio/mpeg")) {
 						String file = j.getJSONArray("attachments").getJSONObject(0).getString("title_link")
 								.substring(1);
 						JSONObject bodyJSON = new JSONObject();

--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
@@ -511,7 +511,7 @@ public class RocketChatMediator extends ChatMediator implements ConnectListener,
 					String fileName = j.getJSONObject("file").getString("name");
 					System.out.println(j);
 					if (fileType.equals("text/plain") || fileType.equals("application/pdf")
-							|| fileType.equals("image/png")) {
+							|| fileType.equals("image/png") || fileType.equals("audio/aac")) {
 						String file = j.getJSONArray("attachments").getJSONObject(0).getString("title_link")
 								.substring(1);
 						JSONObject bodyJSON = new JSONObject();

--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
@@ -511,7 +511,7 @@ public class RocketChatMediator extends ChatMediator implements ConnectListener,
 					String fileName = j.getJSONObject("file").getString("name");
 					System.out.println(j);
 					if (fileType.equals("text/plain") || fileType.equals("application/pdf")
-							|| fileType.equals("image/png") || fileType.equals("audio/aac")) {
+							|| fileType.equals("image/png") || fileType.equals("audio/aac")) || fileType.equals("audio/mpeg") {
 						String file = j.getJSONArray("attachments").getJSONObject(0).getString("title_link")
 								.substring(1);
 						JSONObject bodyJSON = new JSONObject();

--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/RocketChatMediator.java
@@ -511,7 +511,7 @@ public class RocketChatMediator extends ChatMediator implements ConnectListener,
 					String fileName = j.getJSONObject("file").getString("name");
 					System.out.println(j);
 					if (fileType.equals("text/plain") || fileType.equals("application/pdf")
-							|| fileType.equals("image/png") || fileType.equals("audio/aac") || fileType.equals("audio/mpeg")) {
+							|| fileType.equals("image/png") || fileType.equals("audio/aac") || fileType.equals("audio/mpeg") || fileType.equals("audio/x-m4a")) {
 						String file = j.getJSONArray("attachments").getJSONObject(0).getString("title_link")
 								.substring(1);
 						JSONObject bodyJSON = new JSONObject();

--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/TelegramChatMediator.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/chat/TelegramChatMediator.java
@@ -108,6 +108,7 @@ public class TelegramChatMediator extends EventChatMediator {
 			JSONObject chat = (JSONObject) message.get("chat");
 			JSONObject from = (JSONObject) message.get("from");
 			JSONObject document = (JSONObject) message.get("document");
+			JSONObject audio = (JSONObject) message.get("audio");
 			String channel = chat.getAsString("id");
 			String user = from.getAsString("first_name");
 			String text = message.getAsString("text");
@@ -133,7 +134,14 @@ public class TelegramChatMediator extends EventChatMediator {
 				String fileBody = getFile(fileId);
 				messageCollector
 						.addMessage(new ChatMessage(channel, user, text, timestamp, messageId, fileName, mimeType, fileBody));
-			} else {
+			}
+			else if(audio !=null){
+				String fileId = audio.getAsString("file_id");
+				String mimeType = audio.getAsString("mime_type");
+				String fileBody = getFile(fileId);
+				messageCollector.addMessage(new ChatMessage(channel, user, text, timestamp, messageId, mimeType, fileBody));
+			}			
+			 else {
 				messageCollector.addMessage(new ChatMessage(channel, user, text, timestamp, messageId));
 			}
 


### PR DESCRIPTION
Added the possibility for different audio file formats to be treated by the Rocketchat message mediator to be treated as normal files in order to be processed by later application by the Social Bot Manager Service. These files are automatically converted in to base64 format, and have proven to be able to be used by decoding them with standard methods.