### PR TITLE
Webhook endpoint for sending chat messages

### DIFF
--- a/.github/workflows/docker-CI.yml
+++ b/.github/workflows/docker-CI.yml
@@ -3,7 +3,7 @@ name: Docker Build and Push
 on:
   push:
 
-    branches: [ master, develop, ma-philipp]
+    branches: [ master, develop]
 
 
 jobs:

--- a/.github/workflows/docker-CI.yml
+++ b/.github/workflows/docker-CI.yml
@@ -3,7 +3,7 @@ name: Docker Build and Push
 on:
   push:
 
-    branches: [ master, develop]
+    branches: [ master, develop, ma-philipp]
 
 
 jobs:

--- a/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/SocialBotManagerService.java
+++ b/social-bot-manager/src/main/java/i5/las2peer/services/socialBotManagerService/SocialBotManagerService.java
@@ -614,6 +614,60 @@ public class SocialBotManagerService extends RESTService {
 			return Response.ok().entity(returnString).build();
 		}
 
+		/**
+		 * Endpoint that handles incoming webhook calls.
+		 * @param body JSONObject
+		 * @param botName Name of the bot.
+		 * @return HTTP response
+		 */
+		@POST
+		@Path("/{botName}/webhook")
+		@Consumes(MediaType.APPLICATION_JSON)
+		@ApiResponses(value = {
+				@ApiResponse(code = HttpURLConnection.HTTP_OK, message = "Successfully handled webhook call."),
+				@ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "Bot not found."),
+				@ApiResponse(code = HttpURLConnection.HTTP_BAD_REQUEST, message = "Parse exception, field event is missing or event is unsupported.")
+		})
+		@ApiOperation(value = "Handle webhook calls", notes = "Handles incoming webhook calls.")
+		public Response webhook(String body, @PathParam("botName") String botName) {
+			// check if bot exists
+			Bot bot = null;
+			for(VLE vle : getConfig().getVLEs().values()) {
+				bot = vle.getBots().values().stream().filter(b -> b.getName().equals(botName)).findFirst().get();
+				if(bot != null) break;
+			}
+			if (bot == null)
+				return Response.status(HttpURLConnection.HTTP_NOT_FOUND).entity("Bot " + botName + " not found.").build();
+
+			try {
+				// parse body
+				JSONParser p = new JSONParser(JSONParser.MODE_PERMISSIVE);
+				JSONObject parsedBody = (JSONObject) p.parse(body);
+
+				// all webhook calls need to include the "event" property
+				if(!parsedBody.containsKey("event"))
+					return Response.status(HttpURLConnection.HTTP_BAD_REQUEST).entity("Field event is missing.").build();
+
+				String event = parsedBody.getAsString("event");
+				// handle webhook depending on the event (currently only chat_message supported)
+				if(event.equals("chat_message")) {
+					String messenger = parsedBody.getAsString("messenger");
+					ChatMediator chat = bot.getMessenger(messenger).getChatMediator();
+
+					// send message
+					JSONObject chatBody = new JSONObject();
+					chatBody.put("channel", parsedBody.getAsString("channel"));
+					chatBody.put("text", parsedBody.getAsString("message"));
+					this.sbfservice.triggerChat(chat, chatBody);
+
+					return Response.status(HttpURLConnection.HTTP_OK).build();
+				}
+				return Response.status(HttpURLConnection.HTTP_BAD_REQUEST).entity("Unsupported event.").build();
+			} catch (ParseException e) {
+				return Response.status(HttpURLConnection.HTTP_BAD_REQUEST).entity("Body parse exception.").build();
+			}
+		}
+
 		@POST
 		@Path("/{botName}/trigger/service")
 		@Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
This PR corresponds to #120.
It adds a webhook endpoint (for each bot) that receives webhook calls.
This could be used to handle different "events" later, but this PR only implements the `chat_message` event that sends a given chat message to a given channel in a given messenger.

Sending a `POST` request to `/SBFManager/bots/<BotName>/webhook` containing the following body
```json
{
    "event": "chat_message",
    "messenger": "RocketChat",
    "channel": "<channelId>",
    "message": "hello!"
}
```
would trigger the bot to send a message to the given RocketChat channel.
I think this should also work for other messengers, because the implementation calls the `triggerChat` function.
Any feedback is highly appreciated!